### PR TITLE
Fix Ediff re(di)f(f)inements

### DIFF
--- a/custom.el
+++ b/custom.el
@@ -171,8 +171,12 @@
  ;; Your init file should contain only one such instance.
  ;; If there is more than one, they won't work right.
  `(default ((t (,@tuple-mono-font :slant normal :weight normal :height 100 :width normal :foundry "CTDB"))))
- '(ediff-even-diff-A ((t (:inherit magit-diff-added-highlight))))
- '(ediff-fine-diff-A ((t (:inherit diff-refine-added))))
+ '(ediff-current-diff-A ((t (:inherit magit-diff-removed-highlight :background nil))))
+ '(ediff-even-diff-A ((t (:inherit magit-diff-removed-highlight))))
+ '(ediff-fine-diff-A ((t (:inherit diff-refine-removed))))
+ '(ediff-current-diff-B ((t (:inherit magit-diff-added-highlight))))
+ '(ediff-even-diff-B ((t (:inherit magit-diff-added-highlight))))
+ '(ediff-fine-diff-B ((t (:inherit diff-refine-added))))
  `(fixed-pitch ((t (,@tuple-mono-font :slant normal :weight normal :height 100 :width normal :foundry "CTDB"))))
  `(lsp-lens-face ((t (,@tuple-mono-font :foundry "CTDB" :inherit lsp-details-face))))
  '(menu ((t (:inherit mode-line))))


### PR DESCRIPTION
This simple PR:
- fixes the `diff-A` coloring (moving it to `diff-B`)
- improves the coloring by adding both `diff-A` and `diff-B` themes