### PR TITLE
Set compilation-max-output-line-length to nil

### DIFF
--- a/custom.el
+++ b/custom.el
@@ -18,6 +18,7 @@
  '(blink-cursor-mode t)
  '(calendar-month-abbrev-array
    ["Jan" "Fév" "Mar" "Avr" "Mai" "Jun" "Jul" "Aoû" "Sep" "Oct" "Nov" "Déc"])
+ '(compilation-max-output-line-length nil)
  '(completion-ignored-extensions (remove ".git/" completion-ignored-extensions))
  '(completion-styles '(hotfuzz basic))
  '(crdt-tuntox-executable (file-truename "~/tuntox-x64"))


### PR DESCRIPTION
Allows to avoid the compilation progress to collapse into `[...]` when `dune build`